### PR TITLE
Update Max Planck Institutes in members list.

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,7 +218,8 @@
                     <li>Kunsthistorisches Institut, Universität Zürich</li>
                     <li>Lehrstuhl für deutsche Philologie (ältere Abteilung), Universität Würzburg</li>
                     <li>Lehrstuhl für Künstliche Intelligenz und Wissenssysteme, Universität Würzburg</li>
-                    <li>Max-Planck-Institut für europäische Rechtsgeschichte Frankfurt am Main</li>
+                    <li>Max-Planck-Institut für Rechtsgeschichte und Rechtstheorie, Frankfurt am Main</li>
+		    <li>Max-Planck-Institut zur Erforschung von Gemeinschaftsgütern, Bonn</li>
                     <li>Österreichische Akademie der Wissenschaften</li>
                     <li>Pattern Recognition Lab, Friedrich-Alexander-Universität Erlangen-Nürnberg</li>
                     <li>Romanisches Seminar, Universität Tübingen</li>


### PR DESCRIPTION
MPI für eur. Rechtsgeschichte wurde umbenannt und die Kollektivgüter sind noch nicht dabei gewesen.